### PR TITLE
Use StringBuilder instead of concatenation in loops

### DIFF
--- a/src/vazkii/rem/command/CommandDongers.java
+++ b/src/vazkii/rem/command/CommandDongers.java
@@ -14,10 +14,11 @@ public class CommandDongers extends Command {
 	public void trigger(PircBot bot, String channel, String sender, String login, String hostname, List<String> tokens) {
 		String guy = "\u30FD\u0F3C\u0E88\u0644\u035C\u0E88\u0F3D\uFF89";
 
-		String dongermsg = "";
+		String dongerBuilder = new StringBuilder();
 		for(String s : tokens)
-			dongermsg = dongermsg + s + " ";
+			dongerBuilder.append(s).append(" ");
 
+		String dongermsg = dongerBuilder.toString();
 		String riot = guy + " RAISE YOUR " + (dongermsg.isEmpty() ? "DONGERS" : dongermsg.toUpperCase()) + guy;
 		bot.sendMessage(channel, riot);
 	}

--- a/src/vazkii/rem/command/CommandFlip.java
+++ b/src/vazkii/rem/command/CommandFlip.java
@@ -83,10 +83,11 @@ public class CommandFlip extends Command {
 	public void trigger(PircBot bot, String channel, String sender, String login, String hostname, List<String> tokens) {
 		String guy = "(\u256f\u00b0\u25a1\u00b0)\u256f\ufe35 ";
 
-		String flipmsg = "";
+		StringBuilder flipBuilder = new StringBuilder();
 		for(String s : tokens)
-			flipmsg = flipmsg + s + " ";
+			flipBuilder.append(s).append(" ");
 
+		String flipmsg = flipBuilder.toString();
 		String riot = guy + (flipmsg.isEmpty() ? "\u253b\u2501\u253b" : flip(flipmsg));
 		bot.sendMessage(channel, riot);
 	}

--- a/src/vazkii/rem/command/CommandRiot.java
+++ b/src/vazkii/rem/command/CommandRiot.java
@@ -14,10 +14,11 @@ public class CommandRiot extends Command {
 	public void trigger(PircBot bot, String channel, String sender, String login, String hostname, List<String> tokens) {
 		String guy = "\u0F3C \u3064 \u25D5_\u25D5 \u0F3D\u3064";
 
-		String riotmsg = "";
+		StringBuilder riotBuilder = new StringBuilder();
 		for(String s : tokens)
-			riotmsg = riotmsg + s + " ";
+			riotBuilder.append(s).append(" ");
 
+		String riotmsg = riotBuilder.toString();
 		String riot = guy + " " + (riotmsg.isEmpty() ? "RIOT" : (riotmsg.toUpperCase() + "OR RIOT")) + " " + guy;
 		bot.sendMessage(channel, riot);
 	}


### PR DESCRIPTION
Last time I checked, the compiler is not very good at compiling String concatenation when it happens in a loop, because concatenation compiles into StringBuilders when possible. In other words, `for (String s : whatever) string = string + s;` is really `for (String s : whatever) string = new StringBuilder().append(string).append(s).toString();`
